### PR TITLE
Doc Id generation change

### DIFF
--- a/x/orbis/keeper/msg_server.go
+++ b/x/orbis/keeper/msg_server.go
@@ -797,7 +797,10 @@ func (k *Keeper) StoreDocument(goCtx context.Context, msg *types.MsgStoreDocumen
 	tier := optionalStoreDocumentTier(msg)
 	timestamp := optionalStoreDocumentTimestamp(msg)
 
-	documentID := types.GenerateDocumentID(msg.RingId, msg.Document, msg.Proof, msg.PolicyId, msg.Resource, msg.Permission, tier, timestamp)
+	documentID, err := types.GenerateDocumentID(msg.RingId, msg.Document, msg.Proof, msg.PolicyId, msg.Resource, msg.Permission, tier, timestamp)
+	if err != nil {
+		return nil, errorsmod.Wrap(types.ErrInvalidDocument, err.Error())
+	}
 	if existing := k.GetDocument(goCtx, documentID); existing != nil {
 		return nil, types.ErrDocumentAlreadyExists
 	}

--- a/x/orbis/keeper/msg_server_test.go
+++ b/x/orbis/keeper/msg_server_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/sourcenetwork/vera/x/orbis/types"
 )
 
+// Well-formed orbis-rs `Secret` / `EncryptionProof` JSON for StoreDocument tests
+// (GenerateDocumentID now parses these to derive a serialization-independent id).
+const testDocumentJSON = `{"enc_cmt":[1,2,3],"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0]}`
+const testProofJSON = `{"challenge":[7,8],"response":[9,10]}`
+
 const testDID = "did:example:orbis-creator"
 const testPolicyOwnerDID = "did:example:orbis-policy-owner"
 const testOperatorDID = "did:example:orbis-operator"
@@ -119,8 +124,8 @@ func TestMsgServer_CreateRingStoreDocumentAndKeyDerivation(t *testing.T) {
 	storeDocumentMsg := &types.MsgStoreDocument{
 		Creator:    creatorAddr,
 		RingId:     createRingResp.RingId,
-		Document:   "ciphertext",
-		Proof:      "proof",
+		Document:   testDocumentJSON,
+		Proof:      testProofJSON,
 		PolicyId:   "policy-doc",
 		Resource:   "secret",
 		Permission: "decrypt",
@@ -133,11 +138,9 @@ func TestMsgServer_CreateRingStoreDocumentAndKeyDerivation(t *testing.T) {
 	}
 	storeDocumentResp, err := k.StoreDocument(ctx, storeDocumentMsg)
 	require.NoError(t, err)
-	require.Equal(
-		t,
-		types.GenerateDocumentID(createRingResp.RingId, "ciphertext", "proof", "policy-doc", "secret", "decrypt", immutable.Some(tier), immutable.Some(timestamp)),
-		storeDocumentResp.DocumentId,
-	)
+	expectedDocID, err := types.GenerateDocumentID(createRingResp.RingId, testDocumentJSON, testProofJSON, "policy-doc", "secret", "decrypt", immutable.Some(tier), immutable.Some(timestamp))
+	require.NoError(t, err)
+	require.Equal(t, expectedDocID, storeDocumentResp.DocumentId)
 
 	document := k.GetDocument(ctx, storeDocumentResp.DocumentId)
 	require.NotNil(t, document)
@@ -875,18 +878,16 @@ func TestMsgServer_AbsentOptionalFieldsAreTreatedAsNone(t *testing.T) {
 	storeDocumentResp, err := k.StoreDocument(ctx, &types.MsgStoreDocument{
 		Creator:    creatorAddr,
 		RingId:     createRingResp.RingId,
-		Document:   "ciphertext",
-		Proof:      "proof",
+		Document:   testDocumentJSON,
+		Proof:      testProofJSON,
 		PolicyId:   "policy-doc",
 		Resource:   "secret",
 		Permission: "decrypt",
 	})
 	require.NoError(t, err)
-	require.Equal(
-		t,
-		types.GenerateDocumentID(createRingResp.RingId, "ciphertext", "proof", "policy-doc", "secret", "decrypt", immutable.None[string](), immutable.None[uint64]()),
-		storeDocumentResp.DocumentId,
-	)
+	expectedDocID, err := types.GenerateDocumentID(createRingResp.RingId, testDocumentJSON, testProofJSON, "policy-doc", "secret", "decrypt", immutable.None[string](), immutable.None[uint64]())
+	require.NoError(t, err)
+	require.Equal(t, expectedDocID, storeDocumentResp.DocumentId)
 }
 
 func TestMsgServer_CreateRingRejectsPSSIntervalBelowMinimum(t *testing.T) {

--- a/x/orbis/types/docid_crossimpl_test.go
+++ b/x/orbis/types/docid_crossimpl_test.go
@@ -7,21 +7,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Must stay byte-identical with orbis-rs `generate_document_id`: whitespace and
+// field order do not change the id, and any extra / differently-cased key is
+// rejected on both sides.
 func TestGenerateDocumentID_CrossImplVectorAndMalleability(t *testing.T) {
 	const d1 = `{"enc_cmt":[1,2,3],"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0]}`
-	const d2 = "{ \"nonce\" : [0,0,0,0,0,0,0,0,0,0,0,0],\n  \"enc_cmt\": [1, 2, 3] ,\"encrypted_data\":[4,5,6] , \"extra\":\"ignored\" }"
+	const d2 = "{ \"nonce\" : [0,0,0,0,0,0,0,0,0,0,0,0],\n  \"enc_cmt\": [1, 2, 3] ,\"encrypted_data\":[4,5,6] }"
 	const p = `{"challenge":[7,8],"response":[9,10]}`
 
-	id1, err := GenerateDocumentID("ring-1", d1, p, "policy-b", "document", "read", immutable.Some("gold"), immutable.Some[uint64](1700000000))
-	require.NoError(t, err)
-	id2, err := GenerateDocumentID("ring-1", d2, p, "policy-b", "document", "read", immutable.Some("gold"), immutable.Some[uint64](1700000000))
-	require.NoError(t, err)
+	id := func(doc, proof string) (string, error) {
+		return GenerateDocumentID("ring-1", doc, proof, "policy-b", "document", "read",
+			immutable.Some("gold"), immutable.Some[uint64](1700000000))
+	}
 
-	require.Equal(t, id1, id2, "non-canonical JSON must not change the id")
+	id1, err := id(d1, p)
+	require.NoError(t, err)
+	id2, err := id(d2, p)
+	require.NoError(t, err)
+	require.Equal(t, id1, id2, "whitespace/order must not change the id")
 	require.Equal(t, "a5f065b5d5e02043d5427455daa3809b59d85990b60e7b5fa11dbcbbe2692fbe", id1)
 
-	_, err = GenerateDocumentID("ring-1", "{}", p, "p", "r", "x", immutable.None[string](), immutable.None[uint64]())
-	require.Error(t, err, "missing document fields must be rejected")
-	_, err = GenerateDocumentID("ring-1", d1, "not json", "p", "r", "x", immutable.None[string](), immutable.None[uint64]())
-	require.Error(t, err, "malformed proof must be rejected")
+	// Rejections — each must fail identically on the Rust side.
+	_, err = id("{}", p)
+	require.Error(t, err, "missing document fields")
+	_, err = id(d1, "not json")
+	require.Error(t, err, "malformed proof")
+	_, err = id(`{"enc_cmt":[1,2,3],"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0],"extra":1}`, p)
+	require.Error(t, err, "unknown field")
+	_, err = id(`{"enc_cmt":[1,2,3],"ENC_CMT":[9,9,9],"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0]}`, p)
+	require.Error(t, err, "case-variant duplicate key must not be foldable into a second id")
+	_, err = id(d1, `{"challenge":[7,8],"response":[9,10],"Response":[0]}`)
+	require.Error(t, err, "case-variant duplicate key in proof")
 }

--- a/x/orbis/types/docid_crossimpl_test.go
+++ b/x/orbis/types/docid_crossimpl_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateDocumentID_CrossImplVectorAndMalleability(t *testing.T) {
+	const d1 = `{"enc_cmt":[1,2,3],"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0]}`
+	const d2 = "{ \"nonce\" : [0,0,0,0,0,0,0,0,0,0,0,0],\n  \"enc_cmt\": [1, 2, 3] ,\"encrypted_data\":[4,5,6] , \"extra\":\"ignored\" }"
+	const p = `{"challenge":[7,8],"response":[9,10]}`
+
+	id1, err := GenerateDocumentID("ring-1", d1, p, "policy-b", "document", "read", immutable.Some("gold"), immutable.Some[uint64](1700000000))
+	require.NoError(t, err)
+	id2, err := GenerateDocumentID("ring-1", d2, p, "policy-b", "document", "read", immutable.Some("gold"), immutable.Some[uint64](1700000000))
+	require.NoError(t, err)
+
+	require.Equal(t, id1, id2, "non-canonical JSON must not change the id")
+	require.Equal(t, "a5f065b5d5e02043d5427455daa3809b59d85990b60e7b5fa11dbcbbe2692fbe", id1)
+
+	_, err = GenerateDocumentID("ring-1", "{}", p, "p", "r", "x", immutable.None[string](), immutable.None[uint64]())
+	require.Error(t, err, "missing document fields must be rejected")
+	_, err = GenerateDocumentID("ring-1", d1, "not json", "p", "r", "x", immutable.None[string](), immutable.None[uint64]())
+	require.Error(t, err, "malformed proof must be rejected")
+}

--- a/x/orbis/types/docid_crossimpl_test.go
+++ b/x/orbis/types/docid_crossimpl_test.go
@@ -25,7 +25,7 @@ func TestGenerateDocumentID_CrossImplVectorAndMalleability(t *testing.T) {
 	id2, err := id(d2, p)
 	require.NoError(t, err)
 	require.Equal(t, id1, id2, "whitespace/order must not change the id")
-	require.Equal(t, "a5f065b5d5e02043d5427455daa3809b59d85990b60e7b5fa11dbcbbe2692fbe", id1)
+	require.Equal(t, "e555cfcb145edf3d4cd8acbae93e05dc3a48eb0162b3af90f42064ab837c9a06", id1)
 
 	// Rejections — each must fail identically on the Rust side.
 	_, err = id("{}", p)

--- a/x/orbis/types/docid_crossimpl_test.go
+++ b/x/orbis/types/docid_crossimpl_test.go
@@ -38,4 +38,12 @@ func TestGenerateDocumentID_CrossImplVectorAndMalleability(t *testing.T) {
 	require.Error(t, err, "case-variant duplicate key must not be foldable into a second id")
 	_, err = id(d1, `{"challenge":[7,8],"response":[9,10],"Response":[0]}`)
 	require.Error(t, err, "case-variant duplicate key in proof")
+	_, err = id(`{"enc_cmt":[1,2,3],"enc_cmt":[9,9,9],"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0]}`, p)
+	require.Error(t, err, "exact duplicate key must not collapse silently (Serde errors 'duplicate field')")
+	_, err = id(`{"enc_cmt":null,"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0]}`, p)
+	require.Error(t, err, "explicit null value (Serde rejects null for Vec<u8>)")
+	_, err = id(`{"enc_cmt":[1,null,3],"encrypted_data":[4,5,6],"nonce":[0,0,0,0,0,0,0,0,0,0,0,0]}`, p)
+	require.Error(t, err, "null array element (Serde rejects null for u8)")
+	_, err = id(d1, p+"  trailing")
+	require.Error(t, err, "trailing data after the JSON object")
 }

--- a/x/orbis/types/keys.go
+++ b/x/orbis/types/keys.go
@@ -101,19 +101,36 @@ func (b *idBytes) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// idDocumentSecret / idDocumentProof mirror the orbis-rs crypto `Secret` /
-// `EncryptionProof` — only the fields needed to derive a canonical,
-// serialization-independent document id. Pointer fields so a missing field is
-// rejected rather than silently treated as empty (matching the Rust side).
-type idDocumentSecret struct {
-	EncCmt        *idBytes `json:"enc_cmt"`
-	EncryptedData *idBytes `json:"encrypted_data"`
-	Nonce         *idBytes `json:"nonce"`
-}
-
-type idDocumentProof struct {
-	Challenge *idBytes `json:"challenge"`
-	Response  *idBytes `json:"response"`
+// decodeIDByteFields parses `raw` as a JSON object that must contain *exactly*
+// the fields in `want` (same names, same case, nothing extra) and decodes each
+// value as a serde-style byte array.
+//
+// The exact-key requirement matters: Go's encoding/json matches struct fields
+// case-insensitively, so a struct decode of `{"enc_cmt":[1],"ENC_CMT":[9]}`
+// would yield [9] here while Serde on the orbis-rs side yields [1] — one
+// ciphertext, two object ids. Decoding through a map keyed on the exact JSON
+// string, and rejecting any key not in `want`, keeps both sides in agreement.
+func decodeIDByteFields(raw string, want []string) (map[string][]byte, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, err
+	}
+	if len(m) != len(want) {
+		return nil, fmt.Errorf("expected exactly fields %v, got %d fields", want, len(m))
+	}
+	out := make(map[string][]byte, len(want))
+	for _, key := range want {
+		v, ok := m[key]
+		if !ok {
+			return nil, fmt.Errorf("missing or misnamed field %q", key)
+		}
+		var b idBytes
+		if err := b.UnmarshalJSON(v); err != nil {
+			return nil, fmt.Errorf("field %q: %w", key, err)
+		}
+		out[key] = b
+	}
+	return out, nil
 }
 
 // GenerateDocumentID returns the stable ID for an encrypted document.
@@ -122,7 +139,7 @@ type idDocumentProof struct {
 // parsed and re-encoded into a canonical length-prefixed form before hashing, so
 // two byte-different JSON encodings of the *same* ciphertext produce the *same*
 // id — a semantic ciphertext has exactly one authorization identity. Returns an
-// error if either blob is not the expected shape.
+// error if either blob is not exactly the expected shape.
 func GenerateDocumentID(
 	ringID string,
 	document string,
@@ -133,28 +150,22 @@ func GenerateDocumentID(
 	tier immutable.Option[string],
 	timestamp immutable.Option[uint64],
 ) (string, error) {
-	var secret idDocumentSecret
-	if err := json.Unmarshal([]byte(document), &secret); err != nil {
+	secret, err := decodeIDByteFields(document, []string{"enc_cmt", "encrypted_data", "nonce"})
+	if err != nil {
 		return "", fmt.Errorf("malformed document: %w", err)
 	}
-	if secret.EncCmt == nil || secret.EncryptedData == nil || secret.Nonce == nil {
-		return "", fmt.Errorf("malformed document: missing enc_cmt, encrypted_data, or nonce")
-	}
-	var pf idDocumentProof
-	if err := json.Unmarshal([]byte(proof), &pf); err != nil {
+	pf, err := decodeIDByteFields(proof, []string{"challenge", "response"})
+	if err != nil {
 		return "", fmt.Errorf("malformed proof: %w", err)
-	}
-	if pf.Challenge == nil || pf.Response == nil {
-		return "", fmt.Errorf("malformed proof: missing challenge or response")
 	}
 
 	h := newIDHasher("orbis/document/v2")
 	h.writeString(ringID)
-	h.writeBytes(*secret.EncCmt)
-	h.writeBytes(*secret.EncryptedData)
-	h.writeBytes(*secret.Nonce)
-	h.writeBytes(*pf.Challenge)
-	h.writeBytes(*pf.Response)
+	h.writeBytes(secret["enc_cmt"])
+	h.writeBytes(secret["encrypted_data"])
+	h.writeBytes(secret["nonce"])
+	h.writeBytes(pf["challenge"])
+	h.writeBytes(pf["response"])
 	h.writeString(policyID)
 	h.writeString(resource)
 	h.writeString(permission)

--- a/x/orbis/types/keys.go
+++ b/x/orbis/types/keys.go
@@ -220,7 +220,7 @@ func GenerateDocumentID(
 		return "", fmt.Errorf("malformed proof: %w", err)
 	}
 
-	h := newIDHasher("orbis/document/v2")
+	h := newIDHasher("orbis/document/v1")
 	h.writeString(ringID)
 	h.writeBytes(secret["enc_cmt"])
 	h.writeBytes(secret["encrypted_data"])

--- a/x/orbis/types/keys.go
+++ b/x/orbis/types/keys.go
@@ -1,12 +1,15 @@
 package types
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"slices"
+	"strings"
 
 	"github.com/sourcenetwork/immutable"
 )
@@ -83,15 +86,31 @@ func (h *idHasher) writeBool(value bool) {
 // idBytes decodes a serde_json-encoded Rust Vec<u8>: a JSON array of integers in
 // 0-255. (Go's encoding/json would natively expect base64 for []byte, which is
 // why a custom decoder is needed to interoperate with orbis-rs.)
+//
+// It rejects an explicit `null` — for the whole value or for any element —
+// because Serde on the orbis-rs side rejects both (a `Vec<u8>` / `u8` cannot
+// deserialize from `null`), whereas Go's stdlib would silently treat them as an
+// empty slice / a zero byte. A parser that is more lenient here than Serde lets
+// Vera mint an id for a document no node will accept.
 type idBytes []byte
 
 func (b *idBytes) UnmarshalJSON(data []byte) error {
-	var nums []uint16
-	if err := json.Unmarshal(data, &nums); err != nil {
+	if string(bytes.TrimSpace(data)) == "null" {
+		return fmt.Errorf("expected an array of bytes, got null")
+	}
+	var elems []json.RawMessage
+	if err := json.Unmarshal(data, &elems); err != nil {
 		return err
 	}
-	out := make([]byte, len(nums))
-	for i, n := range nums {
+	out := make([]byte, len(elems))
+	for i, elem := range elems {
+		if string(bytes.TrimSpace(elem)) == "null" {
+			return fmt.Errorf("array element %d is null", i)
+		}
+		var n uint16
+		if err := json.Unmarshal(elem, &n); err != nil {
+			return err
+		}
 		if n > 255 {
 			return fmt.Errorf("byte value %d out of range 0-255", n)
 		}
@@ -102,25 +121,67 @@ func (b *idBytes) UnmarshalJSON(data []byte) error {
 }
 
 // decodeIDByteFields parses `raw` as a JSON object that must contain *exactly*
-// the fields in `want` (same names, same case, nothing extra) and decodes each
-// value as a serde-style byte array.
+// the fields in `want`: same names, same case, nothing extra, and no duplicates.
+// Each value is decoded as a serde-style byte array.
 //
-// The exact-key requirement matters: Go's encoding/json matches struct fields
-// case-insensitively, so a struct decode of `{"enc_cmt":[1],"ENC_CMT":[9]}`
-// would yield [9] here while Serde on the orbis-rs side yields [1] — one
-// ciphertext, two object ids. Decoding through a map keyed on the exact JSON
-// string, and rejecting any key not in `want`, keeps both sides in agreement.
+// Strictness here is a cross-implementation requirement, not politeness. The
+// orbis-rs side parses the same blob with Serde and a `deny_unknown_fields`
+// struct, which rejects unknown keys, duplicate keys, and explicit nulls. Two
+// gaps in a plain `json.Unmarshal` into a map would let this side disagree:
+//   - case folding: `{"enc_cmt":[1],"ENC_CMT":[9]}` would decode to two distinct
+//     map keys here but collide under Serde. The exact-`want` lookup + count
+//     check below rejects it.
+//   - duplicate exact keys: `{"enc_cmt":[1],"enc_cmt":[9],...}` collapses to a
+//     single map entry (last value wins) with no error, so the count check
+//     cannot see it. Serde errors "duplicate field". We stream the object with a
+//     json.Decoder and reject a repeated key outright.
+//
+// Either disagreement lets one ciphertext acquire two authorization identities.
 func decodeIDByteFields(raw string, want []string) (map[string][]byte, error) {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+	dec := json.NewDecoder(strings.NewReader(raw))
+
+	openTok, err := dec.Token()
+	if err != nil {
 		return nil, err
 	}
-	if len(m) != len(want) {
-		return nil, fmt.Errorf("expected exactly fields %v, got %d fields", want, len(m))
+	if delim, ok := openTok.(json.Delim); !ok || delim != '{' {
+		return nil, fmt.Errorf("expected a JSON object")
+	}
+
+	seen := make(map[string]json.RawMessage, len(want))
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected a string object key, got %v", keyTok)
+		}
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("duplicate field %q", key)
+		}
+		var val json.RawMessage
+		if err := dec.Decode(&val); err != nil {
+			return nil, err
+		}
+		seen[key] = val
+	}
+	// Consume the closing '}' and reject any trailing data after the object,
+	// matching json.Unmarshal's "invalid character after top-level value".
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, fmt.Errorf("unexpected trailing data after JSON object")
+	}
+
+	if len(seen) != len(want) {
+		return nil, fmt.Errorf("expected exactly fields %v, got %d fields", want, len(seen))
 	}
 	out := make(map[string][]byte, len(want))
 	for _, key := range want {
-		v, ok := m[key]
+		v, ok := seen[key]
 		if !ok {
 			return nil, fmt.Errorf("missing or misnamed field %q", key)
 		}

--- a/x/orbis/types/keys.go
+++ b/x/orbis/types/keys.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"slices"
 
 	"github.com/sourcenetwork/immutable"
@@ -78,7 +80,49 @@ func (h *idHasher) writeBool(value bool) {
 	h.bytes = append(h.bytes, 0)
 }
 
+// idBytes decodes a serde_json-encoded Rust Vec<u8>: a JSON array of integers in
+// 0-255. (Go's encoding/json would natively expect base64 for []byte, which is
+// why a custom decoder is needed to interoperate with orbis-rs.)
+type idBytes []byte
+
+func (b *idBytes) UnmarshalJSON(data []byte) error {
+	var nums []uint16
+	if err := json.Unmarshal(data, &nums); err != nil {
+		return err
+	}
+	out := make([]byte, len(nums))
+	for i, n := range nums {
+		if n > 255 {
+			return fmt.Errorf("byte value %d out of range 0-255", n)
+		}
+		out[i] = byte(n)
+	}
+	*b = out
+	return nil
+}
+
+// idDocumentSecret / idDocumentProof mirror the orbis-rs crypto `Secret` /
+// `EncryptionProof` — only the fields needed to derive a canonical,
+// serialization-independent document id. Pointer fields so a missing field is
+// rejected rather than silently treated as empty (matching the Rust side).
+type idDocumentSecret struct {
+	EncCmt        *idBytes `json:"enc_cmt"`
+	EncryptedData *idBytes `json:"encrypted_data"`
+	Nonce         *idBytes `json:"nonce"`
+}
+
+type idDocumentProof struct {
+	Challenge *idBytes `json:"challenge"`
+	Response  *idBytes `json:"response"`
+}
+
 // GenerateDocumentID returns the stable ID for an encrypted document.
+//
+// `document` and `proof` are the JSON blobs from MsgStoreDocument. They are
+// parsed and re-encoded into a canonical length-prefixed form before hashing, so
+// two byte-different JSON encodings of the *same* ciphertext produce the *same*
+// id — a semantic ciphertext has exactly one authorization identity. Returns an
+// error if either blob is not the expected shape.
 func GenerateDocumentID(
 	ringID string,
 	document string,
@@ -88,17 +132,35 @@ func GenerateDocumentID(
 	permission string,
 	tier immutable.Option[string],
 	timestamp immutable.Option[uint64],
-) string {
-	h := newIDHasher("orbis/document/v1")
+) (string, error) {
+	var secret idDocumentSecret
+	if err := json.Unmarshal([]byte(document), &secret); err != nil {
+		return "", fmt.Errorf("malformed document: %w", err)
+	}
+	if secret.EncCmt == nil || secret.EncryptedData == nil || secret.Nonce == nil {
+		return "", fmt.Errorf("malformed document: missing enc_cmt, encrypted_data, or nonce")
+	}
+	var pf idDocumentProof
+	if err := json.Unmarshal([]byte(proof), &pf); err != nil {
+		return "", fmt.Errorf("malformed proof: %w", err)
+	}
+	if pf.Challenge == nil || pf.Response == nil {
+		return "", fmt.Errorf("malformed proof: missing challenge or response")
+	}
+
+	h := newIDHasher("orbis/document/v2")
 	h.writeString(ringID)
-	h.writeString(document)
-	h.writeString(proof)
+	h.writeBytes(*secret.EncCmt)
+	h.writeBytes(*secret.EncryptedData)
+	h.writeBytes(*secret.Nonce)
+	h.writeBytes(*pf.Challenge)
+	h.writeBytes(*pf.Response)
 	h.writeString(policyID)
 	h.writeString(resource)
 	h.writeString(permission)
 	h.writeOptionalString(tier)
 	h.writeOptionalUint64(timestamp)
-	return h.sum()
+	return h.sum(), nil
 }
 
 // GenerateKeyDerivationID returns the stable ID for a key derivation.


### PR DESCRIPTION
GenerateDocumentID hashed the raw JSON text of msg.Document and msg.Proof. Equivalent JSON has different bytes — whitespace, key order, an extra key, a differently-cased key — so one ciphertext could be hashed into multiple distinct object_ids.

  That is a privilege-escalation vector, because the object_id is the ACP authorization identity for a document:

  1. A victim stores a document; PRE re-encryption is gated on ACP permission for its object_id.
  2. An attacker submits MsgStoreDocument directly to the chain with the same ciphertext, re-encoded (reordered keys / added whitespace).
  3. Vera derives a different object_id, the attacker registers it under ACP and becomes its owner, grants themselves reader, and PRE re-encrypts the victim's ciphertext to them.

  The PRE proof binds the parsed payload, not its serialization, so it does not stop this. This was a release blocker.

  Fix

  GenerateDocumentID now parses document (enc_cmt, encrypted_data, nonce) and proof (challenge, response) and hashes a canonical length-prefixed encoding of the decoded bytes rather than the raw strings. Two byte-different encodings of
  the same ciphertext now produce the same id — one semantic ciphertext, exactly one authorization identity. The function is now fallible; StoreDocument maps a parse failure to ErrInvalidDocument.