### PR TITLE
  Bind the ring public key into threshold-signature verification + reject degenerate ring keys

### DIFF
--- a/x/orbis/keeper/msg_server.go
+++ b/x/orbis/keeper/msg_server.go
@@ -119,6 +119,9 @@ func (k *Keeper) FinalizeRing(goCtx context.Context, msg *types.MsgFinalizeRing)
 	if ring.RingPk != "" {
 		return nil, types.ErrRingAlreadyFinalized
 	}
+	if err := rejectIdentityRingPublicKey(msg.RingPk); err != nil {
+		return nil, err
+	}
 
 	signerKey, err := signerPublicKeyHex(ctx, k, msg.Creator)
 	if err != nil {

--- a/x/orbis/keeper/msg_server_reshare_sig_test.go
+++ b/x/orbis/keeper/msg_server_reshare_sig_test.go
@@ -37,6 +37,34 @@ func TestRingReshareSignStateHashIncludesTrustedAuthRelays(t *testing.T) {
 	require.NotEqual(t, withoutRelay, directOnly)
 }
 
+func TestDecaf377IdentityPublicKeyForgeryRejected(t *testing.T) {
+	identityBytes, err := decaf377.Encode(decaf377.Identity())
+	require.NoError(t, err)
+
+	// The underlying Schnorr equation accepts this construction for Y = 0:
+	// choose z, then publish R = z*G. No signing secret is needed.
+	z := big.NewInt(42)
+	generator, err := decaf377.Generator()
+	require.NoError(t, err)
+	rPoint, err := decaf377.ScalarMul(generator, z)
+	require.NoError(t, err)
+	rBytes, err := decaf377.Encode(rPoint)
+	require.NoError(t, err)
+	forgedSignature := append(rBytes, scalarToLittleEndian32(z)...)
+
+	ok, err := orbisfrost.Verify(identityBytes, []byte("identity-key forgery"), forgedSignature)
+	require.NoError(t, err)
+	require.True(t, ok, "regression setup must exercise the underlying identity-key vulnerability")
+
+	err = verifyDecaf377FROSTThresholdSignature(
+		hex.EncodeToString(identityBytes),
+		[]byte("identity-key forgery"),
+		forgedSignature,
+	)
+	require.ErrorIs(t, err, types.ErrInvalidThresholdSignature)
+	require.ErrorIs(t, rejectIdentityRingPublicKey(hex.EncodeToString(identityBytes)), types.ErrInvalidRing)
+}
+
 func TestMsgServer_FinalizeRingReshareByThresholdSignature_BLS12381(t *testing.T) {
 	k, authKeeper, ctx := setupOrbisKeeper(t)
 	ctx = ctx.
@@ -101,14 +129,15 @@ func TestMsgServer_FinalizeRingReshareByThresholdSignature_BLS12381(t *testing.T
 	signBytes, err := ringReshareFinalizeSignBytes(ctx.ChainID(), ring, finalizedRing)
 	require.NoError(t, err)
 
-	dst := []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_")
-	sig := new(blst.P2Affine).Sign(sk, signBytes, dst)
+	// Augmented BLS: the ring public key is prepended to the message.
+	dst := []byte(bls12381G2SignatureAugDST)
+	sig := new(blst.P2Affine).Sign(sk, signBytes, dst, pk.Compress())
 	require.NotNil(t, sig)
 
 	_, err = k.FinalizeRingReshareByThresholdSignature(ctx, &types.MsgFinalizeRingReshareByThresholdSignature{
 		Creator:         creatorAddr,
 		RingId:          ringID,
-		SignatureScheme: ThresholdSignatureSchemeBLS12381G1PKG2SigNUL,
+		SignatureScheme: ThresholdSignatureSchemeBLS12381G1PKG2SigAugV1,
 		Signature:       sig.Compress(),
 	})
 	require.NoError(t, err)

--- a/x/orbis/keeper/msg_server_test.go
+++ b/x/orbis/keeper/msg_server_test.go
@@ -687,6 +687,32 @@ func TestMsgServer_FinalizeRing_UnauthorizedNonPeer(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrInvalidRingFinalizer)
 }
 
+func TestMsgServer_FinalizeRing_RejectsIdentityPublicKey(t *testing.T) {
+	k, authKeeper, ctx := setupOrbisKeeper(t)
+	ctx = ctx.WithValue(appparams.ExtractedDIDContextKey, testDID)
+
+	creatorAddr, _ := testAccountWithPubKey(t, ctx, authKeeper)
+	peerAddr, peerKey := setupPeerWithNodeInfo(t, k, authKeeper, ctx, "12D3KooWPeer1")
+	policyID := createOrbisRingPolicy(t, k, ctx, creatorAddr)
+
+	createRingResp, err := k.CreateRing(ctx, &types.MsgCreateRing{
+		Creator:      creatorAddr,
+		PeerNodeKeys: []string{peerKey},
+		Threshold:    1,
+		PssInterval:  types.MinPSSIntervalSeconds,
+		PolicyId:     policyID,
+	})
+	require.NoError(t, err)
+
+	_, err = k.FinalizeRing(ctx, &types.MsgFinalizeRing{
+		Creator: peerAddr,
+		RingId:  createRingResp.RingId,
+		RingPk:  strings.Repeat("00", decaf377PublicKeySize),
+	})
+	require.ErrorIs(t, err, types.ErrInvalidRing)
+	require.Empty(t, k.GetRing(ctx, createRingResp.RingId).Confirmations)
+}
+
 func TestMsgServer_FinalizeRing_RequiresAllNodes(t *testing.T) {
 	k, authKeeper, ctx := setupOrbisKeeper(t)
 	ctx = ctx.WithValue(appparams.ExtractedDIDContextKey, testDID)

--- a/x/orbis/keeper/report_test.go
+++ b/x/orbis/keeper/report_test.go
@@ -2012,13 +2012,16 @@ func TestMsgServer_SubmitReportRejectsSecurityFailures(t *testing.T) {
 		report := fixture.validReport(t, committeeScopeCurrent, committeeScopeCurrent, 0)
 		_, reportID, err := reportEnvelopeCanonicalMessageAndID(&report)
 		require.NoError(t, err)
-		sig := new(blst.P2Affine).Sign(sk, []byte(reportID), []byte(bls12381G2SignatureDST))
+		// Correct ciphersuite/augmentation, but signs the report ID rather than
+		// the canonical envelope — must still be rejected.
+		pkComp := new(blst.P1Affine).From(sk).Compress()
+		sig := new(blst.P2Affine).Sign(sk, []byte(reportID), []byte(bls12381G2SignatureAugDST), pkComp)
 		require.NotNil(t, sig)
 		_, err = fixture.k.SubmitReport(fixture.ctx, &types.MsgSubmitReport{
 			Creator:         fixture.creator,
 			Report:          report,
 			ReportId:        reportID,
-			SignatureScheme: ThresholdSignatureSchemeBLS12381G1PKG2SigNUL,
+			SignatureScheme: ThresholdSignatureSchemeBLS12381G1PKG2SigAugV1,
 			Signature:       sig.Compress(),
 		})
 		require.ErrorIs(t, err, types.ErrInvalidThresholdSignature)
@@ -2212,13 +2215,15 @@ func (f reportTestFixture) signBLSReport(t *testing.T, sk *blst.SecretKey, repor
 	t.Helper()
 	message, reportID, err := reportEnvelopeCanonicalMessageAndID(&report)
 	require.NoError(t, err)
-	sig := new(blst.P2Affine).Sign(sk, message, []byte(bls12381G2SignatureDST))
+	// Augmented BLS: prepend the compressed ring public key to the message.
+	pkComp := new(blst.P1Affine).From(sk).Compress()
+	sig := new(blst.P2Affine).Sign(sk, message, []byte(bls12381G2SignatureAugDST), pkComp)
 	require.NotNil(t, sig)
 	return &types.MsgSubmitReport{
 		Creator:         f.creator,
 		Report:          report,
 		ReportId:        reportID,
-		SignatureScheme: ThresholdSignatureSchemeBLS12381G1PKG2SigNUL,
+		SignatureScheme: ThresholdSignatureSchemeBLS12381G1PKG2SigAugV1,
 		Signature:       sig.Compress(),
 	}
 }

--- a/x/orbis/keeper/threshold_signature.go
+++ b/x/orbis/keeper/threshold_signature.go
@@ -14,14 +14,21 @@ import (
 )
 
 const (
-	ThresholdSignatureSchemeBLS12381G1PKG2SigNUL = "bls12_381_g1_pk_g2_sig_nul"
-	ThresholdSignatureSchemeDecaf377FROST        = "decaf377_frost"
+	// ThresholdSignatureSchemeBLS12381G1PKG2SigAugV1 is the public-key-augmented
+	// BLS scheme: the ring public key is prepended to the message before
+	// hash-to-curve (IETF "message augmentation"), so a signature cannot be
+	// scaled from one publicly-related derived key onto another. Must stay in
+	// lockstep with orbis-rs `crypto::THRESHOLD_SIGNATURE_SCHEME`. The
+	// pre-augmentation scheme string was "bls12_381_g1_pk_g2_sig_nul".
+	ThresholdSignatureSchemeBLS12381G1PKG2SigAugV1 = "bls12_381_g1_pk_g2_sig_aug_v1"
+	ThresholdSignatureSchemeDecaf377FROST          = "decaf377_frost"
 
-	bls12381PublicKeySize  = 48
-	bls12381SignatureSize  = 96
-	bls12381G2SignatureDST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_"
-	decaf377PublicKeySize  = decaf377.ElementSize
-	decaf377SignatureSize  = decaf377.ElementSize + decaf377.ScalarSize
+	bls12381PublicKeySize = 48
+	bls12381SignatureSize = 96
+	// AUG_ ciphersuite DST (matches orbis-rs `bls12_381::sign::BLS_SIG_DOMAIN`).
+	bls12381G2SignatureAugDST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_"
+	decaf377PublicKeySize     = decaf377.ElementSize
+	decaf377SignatureSize     = decaf377.ElementSize + decaf377.ScalarSize
 )
 
 func verifyThresholdSignatureForRingUpdate(ring *types.Ring, message []byte, scheme string, signature []byte) error {
@@ -30,7 +37,7 @@ func verifyThresholdSignatureForRingUpdate(ring *types.Ring, message []byte, sch
 
 func verifyThresholdSignature(scheme string, ringPK string, message []byte, signature []byte) error {
 	switch normalizeThresholdSignatureScheme(scheme) {
-	case ThresholdSignatureSchemeBLS12381G1PKG2SigNUL:
+	case ThresholdSignatureSchemeBLS12381G1PKG2SigAugV1:
 		return verifyBLS12381ThresholdSignature(ringPK, message, signature)
 	case ThresholdSignatureSchemeDecaf377FROST:
 		return verifyDecaf377FROSTThresholdSignature(ringPK, message, signature)
@@ -55,13 +62,19 @@ func verifyBLS12381ThresholdSignature(ringPK string, message []byte, signature [
 		return errorsmod.Wrapf(types.ErrInvalidThresholdSignature, "invalid bls12_381 signature length %d", len(signature))
 	}
 
+	// Augmented BLS: verify against H(ringPK || message). The two trailing
+	// bools are (useHash, usePksAsAugs) — usePksAsAugs makes blst prepend the
+	// exact `publicKey` bytes to the message, matching orbis-rs which prepends
+	// the compressed ring public key before hash-to-curve.
 	if !new(blst.P2Affine).VerifyCompressed(
 		signature,
 		true,
 		publicKey,
 		true,
 		message,
-		[]byte(bls12381G2SignatureDST),
+		[]byte(bls12381G2SignatureAugDST),
+		true,
+		true,
 	) {
 		return types.ErrInvalidThresholdSignature
 	}
@@ -81,12 +94,46 @@ func verifyDecaf377FROSTThresholdSignature(ringPK string, message []byte, signat
 		return errorsmod.Wrapf(types.ErrInvalidThresholdSignature, "invalid decaf377 signature length %d", len(signature))
 	}
 
+	point, err := decaf377.Decode(publicKey)
+	if err != nil {
+		return errorsmod.Wrapf(types.ErrInvalidThresholdSignature, "invalid decaf377 public key: %s", err)
+	}
+	if decaf377.Equivalent(point, decaf377.Identity()) {
+		return errorsmod.Wrap(types.ErrInvalidThresholdSignature, "decaf377 public key is the identity")
+	}
+
 	ok, err := orbisfrost.Verify(publicKey, message, signature)
 	if err != nil {
 		return errorsmod.Wrapf(types.ErrInvalidThresholdSignature, "invalid decaf377 signature: %s", err)
 	}
 	if !ok {
 		return types.ErrInvalidThresholdSignature
+	}
+
+	return nil
+}
+
+// rejectIdentityRingPublicKey prevents finalizing a ring with the one public
+// key that makes Schnorr verification vacuous. FinalizeRing predates an
+// explicit curve/scheme field and its tests use opaque placeholder keys, so
+// other encoding validation remains in the scheme-specific consumers.
+func rejectIdentityRingPublicKey(ringPK string) error {
+	publicKey, err := decodeHexBytes(ringPK)
+	if err != nil {
+		return nil
+	}
+
+	switch len(publicKey) {
+	case decaf377PublicKeySize:
+		point, err := decaf377.Decode(publicKey)
+		if err == nil && decaf377.Equivalent(point, decaf377.Identity()) {
+			return errorsmod.Wrap(types.ErrInvalidRing, "decaf377 ring public key is the identity")
+		}
+	case bls12381PublicKeySize:
+		point := new(blst.P1Affine).Uncompress(publicKey)
+		if point != nil && !point.KeyValidate() {
+			return errorsmod.Wrap(types.ErrInvalidRing, "bls12_381 ring public key is the identity or outside the prime-order subgroup")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
  Two related hardening changes to x/orbis/keeper threshold-signature verification, both from the recent MPC-signing security review:

  1. Public-key-augmented BLS — verify BLS threshold signatures against H(ringPK ‖ message) instead of H(message), using the IETF AUG_ ciphersuite. Breaking wire change; must ship in lockstep with orbis-rs 
     Add-public-key-to-bls-message-hash.
  2. Reject identity / degenerate ring public keys at FinalizeRing and in the decaf377 FROST verifier.

  1. Public-key augmentation (BLS)

  Problem. orbis-rs derives per-request signing keys multiplicatively: PK = d·xG, and a plain BLS signature is d·x·H(m). The derivation scalar d is a deterministic function of on-chain data (derivation path + policy/resource/permission),
  so it is public. Given a signature σ_a valid under derived key PK_a, anyone can compute σ_v = (d_v · d_a⁻¹) · σ_a, which verifies under any other derived key PK_v on the same ring. Per-derivation access control on signing is
  bypassable by anyone holding any derivation on the ring, including the root key used for reports and ring updates.

  Fix. Message augmentation: hash H(PK ‖ m). H(PK_a ‖ m) and H(PK_v ‖ m) are independent curve points with no scalar relation, so no signature can be scaled onto another key. This matches draft-irtf-cfrg-bls-signature §3.2.

  Changes here:
  - bls12381G2SignatureDST → BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_ (renamed bls12381G2SignatureAugDST).
  - Scheme identifier bls12_381_g1_pk_g2_sig_nul → bls12_381_g1_pk_g2_sig_aug_v1 (renamed ThresholdSignatureSchemeBLS12381G1PKG2SigAugV1). This is the discriminator verifyThresholdSignature dispatches on; it travels in MsgSubmitReport /
    MsgFinalizeRingReshareByThresholdSignature.
  - verifyBLS12381ThresholdSignature passes useHash=true, usePksAsAugs=true to blst.VerifyCompressed, so blst prepends the exact decodeHexBytes(ring.RingPk) bytes — byte-identical to what orbis-rs prepends (ark-bls12-381 0.4 uses
    ZCash/blst-compatible point serialization, so pk.serialize_compressed() on the Rust side equals the stored ring.RingPk).
  - Both consumers (report.go, msg_server.go reshare finalize) verify root-key signatures against ring.RingPk and need no change beyond the dispatch.
  
  FROST/decaf377 needs no augmentation — its Fiat–Shamir challenge already binds the derived public key.

  2. Reject identity / degenerate ring public keys

  Problem. decaf377 Schnorr verification z·G == R + c·Y is vacuous when Y (the public key) is the identity: pick any z, set R = z·G, publish (R, z). orbisfrost.Verify accepted this. BLS was already protected by blst's KeyValidate /
  pkValidate.

  Changes here:
  - verifyDecaf377FROSTThresholdSignature rejects the decaf377 identity element before calling orbisfrost.Verify.
  - New rejectIdentityRingPublicKey, length-dispatched (decaf377 identity check; BLS Uncompress + !KeyValidate()), called from FinalizeRing so a ring can never be finalized with a degenerate key. Undecodable / unknown-length keys are
    left to the scheme-specific verifiers (FinalizeRing predates an explicit scheme field and some tests use placeholder keys).

